### PR TITLE
Use ensure_resource to avoid duplicate resources

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,3 +1,5 @@
 name 'meltwater-cpan'
 version '1.0.1'
 description "Provides a puppet type to easily install perl CPAN modules"
+
+dependency 'puppetlabs/stdlib', '>= 3.0.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,11 +11,11 @@ class cpan (
   case $::osfamily {
     Debian: {
       if $manage_package {
-        package { 'perl-modules': ensure => installed }
-        package { 'gcc': ensure => installed }
-        package { 'make': ensure => installed }
+        ensure_resource('package', 'perl-modules', { ensure => installed })
+        ensure_resource('package','gcc', { ensure => present })
+        ensure_resource('package', 'make', { ensure => present })
         if $local_lib {
-          package {'liblocal-lib-perl': ensure => installed }
+          ensure_resource('package', 'liblocal-lib-perl', { ensure => present })
         }
       }
       if $manage_config {
@@ -38,11 +38,11 @@ class cpan (
     Redhat: {
       if versioncmp($::operatingsystemmajrelease, '6') >= 0 {
         if $manage_package {
-          package { 'perl-CPAN': ensure => installed }
-          package { 'gcc': ensure => installed }
-          package { 'make': ensure => installed }
+          ensure_resource('package', 'perl-CPAN', { ensure => present })
+          ensure_resource('package', 'gcc', { ensure => present })
+          ensure_resource('package', 'make', { ensure => present })
           if $local_lib {
-            package {'perl-local-lib': ensure => installed }
+            ensure_resource('package', 'perl-local-lib', { ensure => present })
           }
         }
         if $manage_config {


### PR DESCRIPTION
Other modules may also declear the make package. Use ensure_resource to avoid the puppet complain about duplicate resource