### PR TITLE
add config hash to parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class cpan (
   $manage_package = true,
   $installdirs = 'site',
   $local_lib = false,
+  $config_hash = { 'build_requires_install_policy' => 'no' },
 ) {
   unless $installdirs =~ /^(perl|site|vendor)$/ {
     fail("installdirs must be one of {perl,site,vendor}")

--- a/templates/Config.pm.erb
+++ b/templates/Config.pm.erb
@@ -64,6 +64,9 @@ $CPAN::Config = {
   'wget' => q[/usr/bin/wget],
   'yaml_load_code' => q[0],
   'yaml_module' => q[YAML],
+  <% @config_hash.each do |k,v| -%>
+    '<%= k -%>' => 'q[<%= v -%>]',
+  <% end -%>
 };
 1;
 __END__


### PR DESCRIPTION
Hello!

I found that the parameter "build_requires_install_policy" spawns questions on installation. Since I didn't know why it has been set to "ask/yes" in the first place I made it as a configuration parameter so everything can be overridden in the config if necessary.

Cheers
Hannes