### PR TITLE
Add umask parameter

### DIFF
--- a/lib/puppet/provider/cpan/default.rb
+++ b/lib/puppet/provider/cpan/default.rb
@@ -31,12 +31,14 @@ Puppet::Type.type(:cpan).provide( :default ) do
       ll = "-Mlocal::lib=#{resource[:local_lib]}"
     end
 
+    umask = "umask #{resource[:umask]};" if resource[:umask]
+
     Puppet.debug("cpan #{resource[:name]}")
     if resource.force?
       Puppet.info("Forcing install for #{resource[:name]}")
-      system("yes | perl #{ll} -MCPAN -e 'CPAN::force CPAN::install #{resource[:name]}'")
+      system("#{umask} yes | perl #{ll} -MCPAN -e 'CPAN::force CPAN::install #{resource[:name]}'")
     else
-      system("yes | perl #{ll} -MCPAN -e 'CPAN::install #{resource[:name]}'")
+      system("#{umask} yes | perl #{ll} -MCPAN -e 'CPAN::install #{resource[:name]}'")
     end
 
     #cpan doesn't always provide the right exit code, so we double check
@@ -57,11 +59,13 @@ Puppet::Type.type(:cpan).provide( :default ) do
     if resource[:local_lib]
       ll = "-Mlocal::lib=#{resource[:local_lib]}"
     end
+    umask = "umask #{resource[:umask]};" if resource[:umask]
+
     if resource.force?
       Puppet.info("Forcing upgrade for #{resource[:name]}")
-      system("yes | perl #{ll} -MCPAN -e 'CPAN::force CPAN::install #{resource[:name]}'")
+      system("#{umask} yes | perl #{ll} -MCPAN -e 'CPAN::force CPAN::install #{resource[:name]}'")
     else
-      system("yes | perl #{ll} -MCPAN -e 'CPAN::install #{resource[:name]}'")
+      system("#{umask} yes | perl #{ll} -MCPAN -e 'CPAN::install #{resource[:name]}'")
     end
     estatus = $?.exitstatus
     

--- a/lib/puppet/type/cpan.rb
+++ b/lib/puppet/type/cpan.rb
@@ -1,7 +1,7 @@
 require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:cpan) do
-  @doc = "Install cpan modules"
+  @doc = 'Install cpan modules'
   ensurable do
     newvalue(:absent) do
       if provider.exists?
@@ -20,17 +20,27 @@ Puppet::Type.newtype(:cpan) do
       unless provider.latest?
         provider.update
       end
-    end 
+    end
   end
 
   newparam(:name) do
-    desc "The name of the module."
+    desc 'The name of the module.'
   end
+
   newparam(:local_lib) do
-    desc "Destination directory or `false`"
+    desc 'Destination directory or `false`'
   end
+
   newparam(:force, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc 'Enable/Disable to force the installation of the module. Disabled by default.'
     defaultto :false
+  end
+
+  newparam(:umask) do
+    desc 'umask to run cpan with'
+    validate do |value|
+      raise ArgumentError, 'string expected for umask' unless value.is_a?(String)
+      raise ArgumentError, 'umask should be a 3 or 4 character octal string' unless value =~ /^[0-7]{3,4}$/
+    end
   end
 end

--- a/spec/unit/puppet/type/cpan_spec.rb
+++ b/spec/unit/puppet/type/cpan_spec.rb
@@ -9,11 +9,13 @@ describe Puppet::Type.type(:cpan) do
       expect { described_class.new(name: 'test', ensure: 'foo') }.to raise_error(Puppet::Error)
     end
   end
+
   describe 'name' do
     it 'is the namevar' do
       expect(described_class.key_attributes).to eq([:name])
     end
   end
+
   describe 'local_lib' do
     it 'accepts an absolute path' do
       expect { described_class.new(name: 'test', local_lib: '/path/to/file') }.not_to raise_error
@@ -22,6 +24,7 @@ describe Puppet::Type.type(:cpan) do
       expect { described_class.new(name: 'test', local_lib: false) }.not_to raise_error
     end
   end
+
   describe 'force' do
     [true, false, 'true', 'false', 'no', 'yes'].each do |value|
       it "accepts #{value}" do
@@ -39,6 +42,23 @@ describe Puppet::Type.type(:cpan) do
     end
     it 'munges \'true\' to true' do
       expect(described_class.new(name: 'test', force: 'true')[:force]).to eq(true)
+    end
+  end
+
+  describe 'umask' do
+    describe 'valid values' do
+      ['0022', '022', '0027', '027'].each do |value|
+        it "accepts #{value}" do
+          expect { described_class.new(name: 'test', umask: value) }.not_to raise_error
+        end
+      end
+    end
+    describe 'invalid values' do
+      [true, false, 220, '0', '888', 'invalid'].each do |value|
+        it "rejects #{value}" do
+          expect { described_class.new(name: 'test', umask: value) }.to raise_error(Puppet::Error)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
My local security policy dictates that the system's default umask has to
be 027 instead of the normal 022.  This meant that CPAN modules being
installed by this puppet module were only readable by root.

This commit adds a new `umask` parameter than can be used to force the
use of a specific umask when creating or updating CPAN modules.